### PR TITLE
Add more Trinket slot options

### DIFF
--- a/kubejs/data/trinkets/tags/items/hand/glove.json
+++ b/kubejs/data/trinkets/tags/items/hand/glove.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "artifacts:digging_claws",
+    "artifacts:feral_claws",
+    "artifacts:fire_gauntlet",
+    "artifacts:pocket_piston",
+    "artifacts:power_glove",
+    "artifacts:vampiric_glove",
+    "artifacts:golden_hook"
+  ]
+}

--- a/kubejs/data/trinkets/tags/items/head/crown.json
+++ b/kubejs/data/trinkets/tags/items/head/crown.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "botania:flight_tiara"
+  ]
+}

--- a/kubejs/data/trinkets/tags/items/offhand/ring.json
+++ b/kubejs/data/trinkets/tags/items/offhand/ring.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "extraalchemy:potion_ring"
+  ]
+}


### PR DESCRIPTION
Add more Trinket slot options to a few items
- Night Vision Goggles: added to head/face slot (is also still in hat slot)
- Flugel Tiara: added to head/crown (is also still in hat slot)
- Artifact's Snorkel: added to head/face slot (is also still in hat slot)
- Extra Alchemy's Potion Ring: added to offhand/ring (like other rings that are in both hand slots)